### PR TITLE
Improved SF Feather Plugin

### DIFF
--- a/Plugins/SF FEATHER/SF FEATHER/CGT.cs
+++ b/Plugins/SF FEATHER/SF FEATHER/CGT.cs
@@ -82,7 +82,7 @@ namespace SF_FEATHER
                         else if (cgt.pxFormat == 0x07)
                             newFile.name += ".TILT";
                         newFile.offset = cgt.bitmapPointer;
-                        newFile.size = cgt.bitmapSize;
+                        newFile.size = cgt.bitmapSize + 0xC;
                     }
                     else if (count == 1)
                     {
@@ -123,7 +123,7 @@ namespace SF_FEATHER
                     {
                         newFile.name += ".TILT";
                         newFile.offset = cgt.bitmapPointer;
-                        newFile.size = cgt.bitmapSize;
+                        newFile.size = cgt.bitmapSize + 0xC;
                     }
                     else if (count == 1)
                     {
@@ -172,7 +172,7 @@ namespace SF_FEATHER
             string byteArrayTMP = Path.GetTempFileName();
             Write_byteArray(byteArrayTMP, decompressed);
 
-            uint bitmapSize = sCGT.bitmapSize - sCGT.paletteSize - sCGT.positionSize*8;
+            uint bitmapSize = sCGT.bitmapSize - sCGT.paletteSize - sCGT.positionSize*8 - 0xC;
 
             BinaryWriter bw = new BinaryWriter(File.OpenWrite(fileOut));
 

--- a/Plugins/SF FEATHER/SF FEATHER/CGT.cs
+++ b/Plugins/SF FEATHER/SF FEATHER/CGT.cs
@@ -1,0 +1,256 @@
+﻿/*
+ * Copyright (C) 2011  pleoNeX
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+ *
+ * By: mn1712trungson
+ * 
+ */
+
+using Ekona;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SF_FEATHER
+{
+    public class CGT
+    {
+        IPluginHost pluginHost;
+        CGTs sCGT;
+        public CGT(IPluginHost pluginHost)
+        {
+            this.pluginHost = pluginHost;
+        }
+
+        public sFolder Unpack(sFile file)
+        {
+            CGTs cgt = new CGTs();
+            BinaryReader br = new BinaryReader(File.OpenRead(file.path));
+
+            cgt.id = br.ReadChars(4);
+            cgt.NULL1 = br.ReadUInt32();
+            cgt.mappingType = br.ReadUInt32();
+            cgt.NULL2 = br.ReadUInt32();
+
+            cgt.pxFormat = br.ReadUInt32();
+            cgt.bitmapSize = br.ReadUInt32();
+            cgt.bitmapPointer = br.ReadUInt32();
+            cgt.paletteSize = br.ReadUInt32();
+
+            cgt.palettePointer = br.ReadUInt32();
+            cgt.positionSize = br.ReadUInt32();
+            cgt.positionPointer = br.ReadUInt32();
+            cgt.NULL3 = br.ReadUInt32();
+
+            br.BaseStream.Position = 0;
+            sFolder unpacked = new sFolder();
+            unpacked.files = new List<sFile>();
+
+            if (cgt.positionPointer != 0)
+            {
+                uint fileNumber = 3;
+                for (int count = 0; count < fileNumber; count++)
+                {
+                    sFile newFile = new sFile();
+                    newFile.name = "0" + count.ToString();
+
+                    if (count == 0)
+                    {
+                        if (cgt.pxFormat == 0x01)
+                            newFile.name += ".T3I5";
+                        else if (cgt.pxFormat == 0x03)
+                            newFile.name += ".TILT";
+                        else if (cgt.pxFormat == 0x04)
+                            newFile.name += ".TILT";
+                        else if (cgt.pxFormat == 0x06)
+                            newFile.name += ".T5I3";
+                        else if (cgt.pxFormat == 0x07)
+                            newFile.name += ".TILT";
+                        newFile.offset = cgt.bitmapPointer;
+                        newFile.size = cgt.bitmapSize;
+                    }
+                    else if (count == 1)
+                    {
+                        if (cgt.pxFormat == 0x01)
+                            newFile.name += ".P3I5";
+                        else if (cgt.pxFormat == 0x03)
+                            newFile.name += ".P16";
+                        else if (cgt.pxFormat == 0x04)
+                            newFile.name += ".P256";
+                        else if (cgt.pxFormat == 0x06)
+                            newFile.name += ".P5I3";
+                        else if (cgt.pxFormat == 0x07 && cgt.palettePointer == cgt.positionPointer)
+                            newFile.name = ".dummy";
+                        newFile.offset = cgt.palettePointer;
+                        newFile.size = cgt.paletteSize;
+                    }
+                    else if (count == 2)
+                    {
+                        newFile.name += ".CPOS";
+                        newFile.offset = cgt.positionPointer;
+                        newFile.size = file.size - cgt.positionPointer;
+                    }
+
+                    newFile.path = file.path;
+                    unpacked.files.Add(newFile);
+                }
+            }
+
+            else if (cgt.positionPointer == 0)
+            {
+                uint fileNumber = 2;
+                for (int count = 0; count < fileNumber; count++)
+                {
+                    sFile newFile = new sFile();
+                    newFile.name = "0" + count.ToString();
+
+                    if (count == 0)
+                    {
+                        newFile.name += ".TILT";
+                        newFile.offset = cgt.bitmapPointer;
+                        newFile.size = cgt.bitmapSize;
+                    }
+                    else if (count == 1)
+                    {
+                        if (cgt.pxFormat == 0x01)
+                            newFile.name += ".P3I5";
+                        else if (cgt.pxFormat == 0x03)
+                            newFile.name += ".P16";
+                        else if (cgt.pxFormat == 0x04)
+                            newFile.name += ".P256";
+                        else if (cgt.pxFormat == 0x06)
+                            newFile.name += ".P5I3";
+                        else if (cgt.pxFormat == 0x07 && cgt.palettePointer == cgt.positionPointer)
+                            newFile.name = ".dummy";
+                        newFile.offset = cgt.palettePointer;
+                        newFile.size = cgt.paletteSize;
+                    }
+
+                    newFile.path = file.path;
+
+                    unpacked.files.Add(newFile);
+                }
+            }
+
+            bool transparency = br.ReadUInt32() == 0x00 ? false : true;
+            if (transparency == true)
+                Console.WriteLine("Transparency = True");
+            else
+                Console.WriteLine("Transparency = False");
+
+            br.Close();
+            sCGT = cgt;
+            return unpacked;
+        }
+
+        public string Pack(sFile file, ref sFolder unpacked)
+        {
+            Unpack(file);
+            string fileout = pluginHost.Get_TempFile();
+
+            SaveCGT(fileout, ref unpacked);
+            return fileout;
+        }
+
+        private void SaveCGT(string fileOut, ref sFolder decompressed)
+        {
+            string byteArrayTMP = Path.GetTempFileName();
+            Write_byteArray(byteArrayTMP, decompressed);
+
+            uint bitmapSize = sCGT.bitmapSize - sCGT.paletteSize - sCGT.positionSize*8;
+
+            BinaryWriter bw = new BinaryWriter(File.OpenWrite(fileOut));
+
+            bw.Write(sCGT.id);
+            bw.Write(sCGT.NULL1);
+            bw.Write(sCGT.mappingType);
+            bw.Write(sCGT.NULL2);
+            bw.Write(sCGT.pxFormat);
+
+            bw.Write(bitmapSize);
+            bw.Write(sCGT.bitmapPointer);
+            bw.Write(sCGT.paletteSize);
+            uint palettePointer = bitmapSize + sCGT.bitmapPointer + 0xC;
+            bw.Write(palettePointer);
+            bw.Write(sCGT.positionSize);
+            uint positionPointer = 0;
+            if (sCGT.pxFormat == 0x07)
+                positionPointer += palettePointer;
+            else
+                positionPointer += palettePointer + sCGT.paletteSize;
+            bw.Write(positionPointer);
+            
+            bw.Write(sCGT.NULL3);
+
+            bw.Write(File.ReadAllBytes(byteArrayTMP));
+
+            bw.Flush();
+            bw.Close();
+
+            File.Delete(byteArrayTMP);
+        }
+
+        private void Write_byteArray(string fileOut, sFolder decompressed)
+        {
+            BinaryWriter bw = new BinaryWriter(File.OpenWrite(fileOut));
+
+            for (int fCount = 0; fCount < decompressed.files.Count; fCount++)
+            {
+                sFile newFile = Search_File(fCount + decompressed.id, decompressed);
+                BinaryReader br = new BinaryReader(File.OpenRead(newFile.path));
+                br.BaseStream.Position = newFile.offset;
+
+                bw.Write(br.ReadBytes((int)newFile.size));
+
+                br.Close();
+                bw.Flush();
+            }
+
+            sCGT.bitmapSize = (uint)new FileInfo(fileOut).Length;
+            bw.Close();
+        }
+
+        private sFile Search_File(int id, sFolder unpacked)
+        {
+            if (unpacked.files is List<sFile>)
+                foreach (sFile archive in unpacked.files)
+                    if (archive.id == id)
+                        return archive;
+
+            return new sFile();
+        }
+
+        public struct CGTs
+        {
+            public char[] id;
+            public uint NULL1;
+            public uint mappingType;
+            public uint NULL2;
+
+            public uint pxFormat;
+            public uint bitmapSize;
+            public uint bitmapPointer;
+            public uint paletteSize;
+
+            public uint palettePointer;
+            public uint positionSize;
+            public uint positionPointer;
+            public uint NULL3;
+        }
+    }
+}

--- a/Plugins/SF FEATHER/SF FEATHER/CGx.cs
+++ b/Plugins/SF FEATHER/SF FEATHER/CGx.cs
@@ -170,8 +170,17 @@ namespace SF_FEATHER
 
             bw.Write(bitmapSize);
             bw.Write(sCGx.paletteSize);
-            uint tileNumber = bitmapSize / 0x20;
-            bw.Write(tileNumber);
+            string ext = new string(sCGx.id);
+            if (ext == "CG4 ")
+            {
+                uint tileNumber = bitmapSize / 0x20;
+                bw.Write(tileNumber);
+            }
+            else if (ext == "CG8 ")
+            {
+                uint tileNumber = bitmapSize / 0x40;
+                bw.Write(tileNumber);
+            }
             bw.Write(sCGx.objectType);
             bw.Write(sCGx.bitmapPointer);
             uint palettePointer = bitmapSize + sCGx.bitmapPointer;

--- a/Plugins/SF FEATHER/SF FEATHER/Helper.cs
+++ b/Plugins/SF FEATHER/SF FEATHER/Helper.cs
@@ -1,0 +1,154 @@
+﻿/*
+ * Copyright (C) 2011  pleoNeX
+ *
+ *   This program is free software: you can redistribute it and/or modify
+ *   it under the terms of the GNU General Public License as published by
+ *   the Free Software Foundation, either version 3 of the License, or
+ *   (at your option) any later version.
+ *
+ *   This program is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU General Public License for more details.
+ *
+ *   You should have received a copy of the GNU General Public License
+ *   along with this program.  If not, see <http://www.gnu.org/licenses/>. 
+ *
+ * By: mn1712trungson
+ * 
+ */
+
+using Ekona.Images;
+using Ekona;
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace SF_FEATHER
+{
+    public class Helper
+    {
+        public static Format ReadRAW(sFile file, IPluginHost pluginHost)
+        {
+            //Palette
+            if (file.name.EndsWith(".P3I5"))
+            {
+                RawPalette palette = new RawPalette(file.path, file.id, true, ColorFormat.A3I5, 0, -1, file.name);
+                pluginHost.Set_Palette(palette);
+                return Format.Palette;
+            }
+            else if (file.name.EndsWith(".P5I3"))
+            {
+                RawPalette palette = new RawPalette(file.path, file.id, true, ColorFormat.A5I3, 0, -1, file.name);
+                pluginHost.Set_Palette(palette);
+                return Format.Palette;
+            }
+            else if (file.name.EndsWith(".P16"))
+            {
+                RawPalette palette = new RawPalette(file.path, file.id, true, ColorFormat.colors16, 0, -1, file.name);
+                pluginHost.Set_Palette(palette);
+                return Format.Palette;
+            }
+            else if (file.name.EndsWith(".P256"))
+            {
+                BinaryReader br = new BinaryReader(File.OpenRead(file.path));
+                int palette_length = 0x200;
+                Color[][] palette = new Color[1][];
+                for (int i = 0; i < palette.Length; i++)
+                    palette[i] = Actions.BGR555ToColor(br.ReadBytes(palette_length));
+
+                br.Close();
+
+                RawPalette pb = new RawPalette(palette, true, ColorFormat.colors256);
+                pluginHost.Set_Palette(pb);
+                return Format.Palette;
+            }
+
+            //Tile
+            ColorFormat depth;
+            if (pluginHost.Get_Palette().Loaded)
+                depth = pluginHost.Get_Palette().Depth;
+            else
+                depth = ColorFormat.direct;
+
+            if (file.name.EndsWith(".TIL8"))
+            {
+                BinaryReader br = new BinaryReader(File.OpenRead(file.path));
+                byte[] data = br.ReadBytes((int)file.size);
+
+                br.Close();
+
+                RawImage image = new RawImage(data, TileForm.Horizontal, ColorFormat.colors256, 0x8, data.Length / 8, true, file.name);
+                pluginHost.Set_Image(image);
+                return Format.Tile;
+            }
+
+            else if (file.name.EndsWith(".TIL4"))
+            {
+                BinaryReader br = new BinaryReader(File.OpenRead(file.path));
+                byte[] data = br.ReadBytes((int)file.size);
+
+                br.Close();
+
+                RawImage image = new RawImage(data, TileForm.Horizontal, ColorFormat.colors16, 0x8, data.Length / 4, true, file.name);
+                pluginHost.Set_Image(image);
+                return Format.Tile;
+            }
+            else if (file.name.EndsWith(".TILT"))
+            {
+                BinaryReader br = new BinaryReader(File.OpenRead(file.path));
+                bool transparency = br.ReadUInt32() == 0x00 ? false : true;
+                Console.WriteLine($"Transparency = {transparency}");
+
+                int width = (int)Math.Pow(2, br.ReadUInt16() + 3);
+                int height = (int)Math.Pow(2, br.ReadUInt16() + 3);
+                uint bitmapArrayPointer = br.ReadUInt32();
+
+                br.Close();
+
+                RawImage image = new RawImage(file.path, file.id, TileForm.Lineal, depth, width, height, true, (int)bitmapArrayPointer, (int)(file.size - bitmapArrayPointer), file.name);
+                pluginHost.Set_Image(image);
+                return Format.Tile;
+            }
+
+            else if (file.name.EndsWith(".T3I5"))
+            {
+                BinaryReader br = new BinaryReader(File.OpenRead(file.path));
+                bool transparency = br.ReadUInt32() == 0x00 ? false : true;
+                Console.WriteLine($"Transparency = {transparency}");
+
+                int width = (int)Math.Pow(2, br.ReadUInt16() + 3);
+                int height = (int)Math.Pow(2, br.ReadUInt16() + 3);
+                uint bitmapArrayPointer = br.ReadUInt32();
+
+                br.Close();
+
+                RawImage image = new RawImage(file.path, file.id, TileForm.Lineal, ColorFormat.A3I5, width, height, true, (int)bitmapArrayPointer, (int)(file.size - bitmapArrayPointer), file.name);
+                pluginHost.Set_Image(image);
+                return Format.Tile;
+            }
+            else if (file.name.EndsWith(".T5I3"))
+            {
+                BinaryReader br = new BinaryReader(File.OpenRead(file.path));
+                bool transparency = br.ReadUInt32() == 0x00 ? false : true;
+                Console.WriteLine($"Transparency = {transparency}");
+
+                int width = (int)Math.Pow(2, br.ReadUInt16() + 3);
+                int height = (int)Math.Pow(2, br.ReadUInt16() + 3);
+                uint bitmapArrayPointer = br.ReadUInt32();
+
+                br.Close();
+
+                RawImage image = new RawImage(file.path, file.id, TileForm.Lineal, ColorFormat.A5I3, width, height, true, (int)bitmapArrayPointer, (int)(file.size - bitmapArrayPointer), file.name);
+                pluginHost.Set_Image(image);
+                return Format.Tile;
+            }
+
+            return Format.Unknown;
+        }
+    }
+}

--- a/Plugins/SF FEATHER/SF FEATHER/Helper.cs
+++ b/Plugins/SF FEATHER/SF FEATHER/Helper.cs
@@ -66,10 +66,10 @@ namespace SF_FEATHER
 
             //Tile
             ColorFormat depth;
+            depth = ColorFormat.direct;
+
             if (pluginHost.Get_Palette().Loaded)
                 depth = pluginHost.Get_Palette().Depth;
-            else
-                depth = ColorFormat.direct;
 
             if (file.name.EndsWith(".TIL8"))
             {

--- a/Plugins/SF FEATHER/SF FEATHER/Helper.cs
+++ b/Plugins/SF FEATHER/SF FEATHER/Helper.cs
@@ -21,12 +21,8 @@
 using Ekona.Images;
 using Ekona;
 using System;
-using System.Collections.Generic;
 using System.Drawing;
 using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace SF_FEATHER
 {
@@ -98,11 +94,11 @@ namespace SF_FEATHER
                 pluginHost.Set_Image(image);
                 return Format.Tile;
             }
+
             else if (file.name.EndsWith(".TILT"))
             {
                 BinaryReader br = new BinaryReader(File.OpenRead(file.path));
-                bool transparency = br.ReadUInt32() == 0x00 ? false : true;
-                Console.WriteLine($"Transparency = {transparency}");
+                uint transparency = br.ReadUInt32();
 
                 int width = (int)Math.Pow(2, br.ReadUInt16() + 3);
                 int height = (int)Math.Pow(2, br.ReadUInt16() + 3);
@@ -118,14 +114,11 @@ namespace SF_FEATHER
             else if (file.name.EndsWith(".T3I5"))
             {
                 BinaryReader br = new BinaryReader(File.OpenRead(file.path));
-                bool transparency = br.ReadUInt32() == 0x00 ? false : true;
-                Console.WriteLine($"Transparency = {transparency}");
+                uint transparency = br.ReadUInt32();
 
                 int width = (int)Math.Pow(2, br.ReadUInt16() + 3);
                 int height = (int)Math.Pow(2, br.ReadUInt16() + 3);
                 uint bitmapArrayPointer = br.ReadUInt32();
-
-                br.Close();
 
                 RawImage image = new RawImage(file.path, file.id, TileForm.Lineal, ColorFormat.A3I5, width, height, true, (int)bitmapArrayPointer, (int)(file.size - bitmapArrayPointer), file.name);
                 pluginHost.Set_Image(image);
@@ -134,8 +127,7 @@ namespace SF_FEATHER
             else if (file.name.EndsWith(".T5I3"))
             {
                 BinaryReader br = new BinaryReader(File.OpenRead(file.path));
-                bool transparency = br.ReadUInt32() == 0x00 ? false : true;
-                Console.WriteLine($"Transparency = {transparency}");
+                uint transparency = br.ReadUInt32();
 
                 int width = (int)Math.Pow(2, br.ReadUInt16() + 3);
                 int height = (int)Math.Pow(2, br.ReadUInt16() + 3);

--- a/Plugins/SF FEATHER/SF FEATHER/Main.cs
+++ b/Plugins/SF FEATHER/SF FEATHER/Main.cs
@@ -19,15 +19,18 @@
  * 
  */
 
+using System;
 using System.IO;
 using System.Text;
 using Ekona;
 using Ekona.Images;
+using static SF_FEATHER.CGT;
 
 namespace SF_FEATHER
 {
     public class Main : IGamePlugin
     {
+
         IPluginHost pluginHost;
         string gameCode;
 

--- a/Plugins/SF FEATHER/SF FEATHER/Main.cs
+++ b/Plugins/SF FEATHER/SF FEATHER/Main.cs
@@ -19,8 +19,6 @@
  * 
  */
 
-using System;
-using System.Drawing;
 using System.IO;
 using System.Text;
 using Ekona;
@@ -81,7 +79,7 @@ namespace SF_FEATHER
                 return Format.Cell;
             else if (ext == "PSI3")
                 return Format.Script;
-            else if (ext == "BIT ")
+            else if (file.name.EndsWith(".BIT"))
                 return Format.Font;
             else if (ext == "ANT ")
                 return Format.Texture;
@@ -101,26 +99,17 @@ namespace SF_FEATHER
 
             if (file.name.EndsWith(".pac"))
             {
-                string fileOut = pluginHost.Get_TempFile();
-                PAC.Pack(file.path, fileOut, ref unpacked);
-
-                return fileOut;
+                return new PAC(pluginHost).Pack(file, ref unpacked);
             }
 
             else if (ext == "CG4 " || ext == "CG8 ")
             {
-                string fileOut = pluginHost.Get_TempFile();
-                CGx.Pack(fileOut, fileOut, ref unpacked);
-
-                return fileOut;
+                return new CGx(pluginHost).Pack(file, ref unpacked);
             }
 
             else if (ext == "CGT ")
             {
-                string fileOut = pluginHost.Get_TempFile();
-                CGT.Pack(fileOut, fileOut, ref unpacked);
-
-                return fileOut;
+                return new CGT(pluginHost).Pack(file, ref unpacked);
             }
             return null;
         }
@@ -132,15 +121,15 @@ namespace SF_FEATHER
             br.Close();
             if (file.name.EndsWith(".pac"))
             {
-                return PAC.Unpack(file.path, file.name);
+                return new PAC(pluginHost).Unpack(file);
             }
             else if (ext == "CG4 " || ext == "CG8 ")
             {
-                return CGx.Unpack(file);
+                return new CGx(pluginHost).Unpack(file);
             }
             else if (ext == "CGT ")
             {
-                return CGT.Unpack(file);
+                return new CGT(pluginHost).Unpack(file);
             }
             return new sFolder();
         }

--- a/Plugins/SF FEATHER/SF FEATHER/PAC.cs
+++ b/Plugins/SF FEATHER/SF FEATHER/PAC.cs
@@ -15,11 +15,12 @@
  *   along with this program.  If not, see <http://www.gnu.org/licenses/>. 
  *
  * By: pleoNeX
+ * Update: mn1712trungson
  * 
  */
+
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 using System.IO;
 using Ekona;
@@ -35,14 +36,15 @@ namespace SF_FEATHER
             sFolder unpacked = new sFolder();
             unpacked.files = new List<sFile>();
 
-            ushort num_element = br.ReadUInt16();
-            ushort unknown = br.ReadUInt16();
-            uint type_file = br.ReadUInt32();
+            ushort fileNumber = br.ReadUInt16();
+            ushort uValue1 = br.ReadUInt16();
+            ushort uValue2 = br.ReadUInt16();
+            ushort padding = br.ReadUInt16();
 
-            for (int i = 0; i < num_element; i++)
+            for (int fCount = 0; fCount < fileNumber; fCount++)
             {
                 sFile newFile = new sFile();
-                newFile.name = name + '_' + i.ToString();
+                newFile.name = name + '_' + fCount.ToString();
                 newFile.offset = br.ReadUInt32() * 0x10;
                 newFile.size = br.ReadUInt32() * 0x10;
                 newFile.path = file;
@@ -53,11 +55,11 @@ namespace SF_FEATHER
                     bool compressed = false;
 
                     // Check if this file is pac, it searches the extension
-                    long currPos = br.BaseStream.Position;
+                    long currentPos = br.BaseStream.Position;
                     br.BaseStream.Position = newFile.offset;
-                    byte cInd = br.ReadByte();
-                    uint cSize = br.ReadUInt32();
-                    if ((cInd == 0x11 || cInd == 0x10) && cSize < 0x2000000)
+                    byte typeLZ = br.ReadByte();
+                    uint compressedSize = br.ReadUInt32();
+                    if ((typeLZ == 0x11 || typeLZ == 0x10) && compressedSize < 0x2000000)
                         compressed = true;
 
                     // Search the indicator of the pac file
@@ -65,9 +67,9 @@ namespace SF_FEATHER
                         br.BaseStream.Position = newFile.offset + 9;
                     else
                         br.BaseStream.Position = newFile.offset + 4;
-                    uint currType = br.ReadUInt32();
+                    uint fileType = br.ReadUInt32();
 
-                    if (currType == 0x04)
+                    if (fileType == 0x04)
                         newFile.name += ".pac";
                     else
                     {
@@ -77,12 +79,12 @@ namespace SF_FEATHER
                         else
                             br.BaseStream.Position = newFile.offset;
                            
-                        currType = br.ReadUInt32();
-                        char[] ext = Encoding.ASCII.GetChars(BitConverter.GetBytes(currType));
+                        fileType = br.ReadUInt32();
+                        char[] ext = Encoding.ASCII.GetChars(BitConverter.GetBytes(fileType));
                         String extS = ".";
-                        for (int s = 0; s < 4; s++)
-                            if (Char.IsLetterOrDigit(ext[s]) || ext[s] == 0x20)
-                                extS += ext[s];
+                        for (int sCount = 0; sCount < 4; sCount++)
+                            if (Char.IsLetterOrDigit(ext[sCount]) || ext[sCount] == 0x20)
+                                extS += ext[sCount];
 
                         if (extS != "." && extS.Length == 5)
                             newFile.name += extS;
@@ -90,7 +92,7 @@ namespace SF_FEATHER
                             newFile.name += ".bin";
                     }
 
-                    br.BaseStream.Position = currPos;
+                    br.BaseStream.Position = currentPos;
                 }
                 else
                     continue;
@@ -102,73 +104,75 @@ namespace SF_FEATHER
             return unpacked;
         }
 
-        public static void Pack(string file_original, string fileOut, ref sFolder unpacked)
+        public static void Pack(string fileOG, string fileOut, ref sFolder unpacked)
         {
-            BinaryReader br = new BinaryReader(File.OpenRead(file_original));
+            BinaryReader br = new BinaryReader(File.OpenRead(fileOG));
             BinaryWriter bw = new BinaryWriter(File.OpenWrite(fileOut));
             List<byte> buffer = new List<byte>();
 
 
-            ushort num_element = br.ReadUInt16();
-            bw.Write(num_element);
-            bw.Write(br.ReadUInt16());  // Unknown
-            bw.Write(br.ReadUInt32());  // Type of element
+            ushort fileNumber = br.ReadUInt16();
+            bw.Write(fileNumber);
+            //uValue1, uValue2, padding
+            bw.Write(br.ReadUInt16());
+            bw.Write(br.ReadUInt16());
+            bw.Write(br.ReadUInt16());
 
-            uint offset = (uint)num_element * 8 + 8;
-            uint size;
-            int f = 0;  // Pointer to the unpacked.files array
+            uint fOffset = (uint)fileNumber * 8 + 8;
+            uint fSize;
+            int unpackedPointer = 0;  // Pointer to the unpacked.files array
 
-            // Write the final padding of the FAT section
-            if (offset % 0x10 != 0)
+            // Write the final padding of the dict section
+            if (fOffset % 0x10 != 0)
             {
-                for (int r = 0; r < 0x10 - (offset % 0x10); r++)
+                for (int dictPadding = 0; dictPadding < 0x10 - (fOffset % 0x10); dictPadding++)
                     buffer.Add(0x00);
 
-                offset += 0x10 - (offset % 0x10);
+                fOffset += 0x10 - (fOffset % 0x10);
             }
 
 
-            for (int i = 0; i < num_element; i++)
+            for (int dictCount = 0; dictCount < fileNumber; dictCount++)
             {
                 uint older_offset = br.ReadUInt32();
-                size = br.ReadUInt32();
+                fSize = br.ReadUInt32();
 
                 // If it's a null file
-                if (size == 0)
+                if (fSize == 0)
                 {
                     bw.Write(older_offset);
-                    bw.Write(size);
+                    bw.Write(fSize);
                     continue;
                 }
 
                 // Get a normalized size
-                size = unpacked.files[f].size;
-                if (size % 0x10 != 0)
-                    size += 0x10 - (size % 0x10);
+                fSize = unpacked.files[unpackedPointer].size;
+                if (fSize % 0x10 != 0)
+                    fSize += 0x10 - (fSize % 0x10);
 
                 // Write the FAT section
-                bw.Write((uint)(offset / 0x10));
-                bw.Write((uint)(size / 0x10));
+                bw.Write((uint)(fOffset / 0x10));
+                bw.Write((uint)(fSize / 0x10));
 
                 // Write file
-                BinaryReader fileRead = new BinaryReader(File.OpenRead(unpacked.files[f].path));
-                fileRead.BaseStream.Position = unpacked.files[f].offset;
-                buffer.AddRange(fileRead.ReadBytes((int)unpacked.files[f].size));                
+                BinaryReader fileRead = new BinaryReader(File.OpenRead(unpacked.files[unpackedPointer].path));
+                fileRead.BaseStream.Position = unpacked.files[unpackedPointer].offset;
+                buffer.AddRange(fileRead.ReadBytes((int)unpacked.files[unpackedPointer].size));                
                 fileRead.Close();
 
                 // Write the padding
-                for (int r = 0; r < (size - unpacked.files[f].size); r++)
+                for (int fPadding = 0; fPadding < (fSize - unpacked.files[unpackedPointer].size); fPadding++)
                     buffer.Add(0x00);
 
                 // Set the new offset
-                sFile newFile = unpacked.files[f];
-                newFile.offset = offset;
+                sFile newFile = unpacked.files[unpackedPointer];
+                newFile.offset = fOffset;
                 newFile.path = fileOut;
-                unpacked.files[f] = newFile;
+                unpacked.files[unpackedPointer] = newFile;
 
                 // Set new offset
-                offset += size;
-                f++;
+                fOffset += fSize;
+                unpackedPointer++;
             }
             bw.Flush();
 

--- a/Plugins/SF FEATHER/SF FEATHER/Properties/AssemblyInfo.cs
+++ b/Plugins/SF FEATHER/SF FEATHER/Properties/AssemblyInfo.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 // conjunto de atributos. Cambie estos atributos para modificar la información
 // asociada con un ensamblado.
 [assembly: AssemblyTitle("SF FEATHER")]
-[assembly: AssemblyDescription("")]
+[assembly: AssemblyDescription("Update mn1712trungson")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Tinke")]

--- a/Plugins/SF FEATHER/SF FEATHER/Properties/Resources.Designer.cs
+++ b/Plugins/SF FEATHER/SF FEATHER/Properties/Resources.Designer.cs
@@ -8,10 +8,9 @@
 // </auto-generated>
 //------------------------------------------------------------------------------
 
-namespace SF_FEATHER.Properties {
-    using System;
-    
-    
+namespace SF_FEATHER.Properties
+{
+
     /// <summary>
     ///   Clase de recurso con establecimiento inflexible de tipos, para buscar cadenas traducidas, etc.
     /// </summary>

--- a/Plugins/SF FEATHER/SF FEATHER/SCx.cs
+++ b/Plugins/SF FEATHER/SF FEATHER/SCx.cs
@@ -15,12 +15,8 @@
  *   along with this program.  If not, see <http://www.gnu.org/licenses/>. 
  *
  * By: pleoNeX
- * 
+ * Update: mn1712trungson
  */
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.IO;
 using Ekona;
 using Ekona.Images;
@@ -29,27 +25,27 @@ namespace SF_FEATHER
 {
     public class SCx : MapBase
     {
-        sSCx scx;
+        sSCx typeSC;
 
         public SCx(string file, int id, string fileName = "") : base(file, id, fileName) { }
 
         public override void Read(string file)
         {
             BinaryReader br = new BinaryReader(File.OpenRead(file));
-            scx = new sSCx();
+            typeSC = new sSCx();
 
-            scx.type = br.ReadChars(4);
-            scx.unknown1 = br.ReadUInt32();
-            scx.unknown2 = br.ReadUInt32();
-            scx.unknown3 = br.ReadUInt32();    // Usually 0x00
-            scx.unknown4 = br.ReadUInt32();
+            typeSC.mSeed = br.ReadChars(4);
+            typeSC.u_Value = br.ReadUInt32();
+            typeSC.mappingType = br.ReadUInt32();
+            typeSC.NULL = br.ReadUInt32();
+            typeSC.u_Value2 = br.ReadUInt32();
 
             ushort width = br.ReadUInt16();
             ushort height = br.ReadUInt16();
-            scx.size_mapData2 = br.ReadUInt32();   // Is alway the same?
-            scx.size_mapData = br.ReadUInt32();
+            typeSC.mapSize1 = br.ReadUInt32();
+            typeSC.mapSize2 = br.ReadUInt32();
 
-            NTFS[] map = new NTFS[scx.size_mapData / 2];
+            NTFS[] map = new NTFS[typeSC.mapSize2 / 2];
             for (int i = 0; i < map.Length; i++)
                 map[i] = Actions.MapInfo(br.ReadUInt16());
 
@@ -60,11 +56,11 @@ namespace SF_FEATHER
         {
             BinaryWriter bw = new BinaryWriter(File.OpenWrite(fileOut));
 
-            bw.Write(scx.type);
-            bw.Write(scx.unknown1);
-            bw.Write(scx.unknown2);
-            bw.Write(scx.unknown3);
-            bw.Write(scx.unknown4);
+            bw.Write(typeSC.mSeed);
+            bw.Write(typeSC.u_Value);
+            bw.Write(typeSC.mappingType);
+            bw.Write(typeSC.NULL);
+            bw.Write(typeSC.u_Value2);
 
             bw.Write((ushort)Width);
             bw.Write((ushort)Height);
@@ -80,14 +76,14 @@ namespace SF_FEATHER
 
         public struct sSCx
         {
-            public char[] type;
-            public uint unknown1;
-            public uint unknown2;
-            public uint unknown3;
-            public uint unknown4;
+            public char[] mSeed;
+            public uint u_Value;
+            public uint mappingType;
+            public uint NULL;
+            public uint u_Value2;
 
-            public uint size_mapData2;
-            public uint size_mapData;
+            public uint mapSize1;
+            public uint mapSize2;
         }
     }
 }

--- a/Plugins/SF FEATHER/SF FEATHER/SF FEATHER.csproj
+++ b/Plugins/SF FEATHER/SF FEATHER/SF FEATHER.csproj
@@ -41,9 +41,11 @@
     <Reference Include="System.Drawing" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CGx.cs" />
+    <Compile Include="Helper.cs" />
     <Compile Include="Main.cs" />
     <Compile Include="PAC.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
@@ -63,6 +65,7 @@
   <ItemGroup>
     <None Include="Resources\picture_save.png" />
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Plugins/SF FEATHER/SF FEATHER/SF FEATHER.csproj
+++ b/Plugins/SF FEATHER/SF FEATHER/SF FEATHER.csproj
@@ -44,6 +44,7 @@
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CGT.cs" />
     <Compile Include="CGx.cs" />
     <Compile Include="Helper.cs" />
     <Compile Include="Main.cs" />


### PR DESCRIPTION
SC4, SC8, CG4, CG8 and CGT files are now editable, extracted and imported.

Can compatible with Summon Night Twin Age.
Change (gameCode == "CS4J") to AS7E (SNTA-Eng) or YSMJ (SNTA-Jap).
Recompile and change the *.DLL name.
